### PR TITLE
Add standalone Terraform metadata

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,13 +1,4 @@
-# Standalone examples and fixtures inherit compatibility from the module.
-rule "terraform_required_providers" {
-  enabled = false
-}
-
-rule "terraform_required_version" {
-  enabled = false
-}
-
-# Interface and fixture variable typing is tracked separately from lint tooling.
+# Module interface typing is tracked separately from lint tooling.
 rule "terraform_typed_variables" {
   enabled = false
 }

--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -5,9 +5,21 @@ Basic usage example using default values.
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -31,7 +43,10 @@ output "vpc" { value = module.vpc }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -56,5 +71,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/custom-named-subnets/README.md
+++ b/examples/custom-named-subnets/README.md
@@ -5,9 +5,21 @@ Example demonstrates setting fully custom names a variety of subnets.
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -18,16 +30,17 @@ provider "aws" {
 }
 
 variable "cidr_block" {
+  type    = string
   default = "10.20.32.0/20"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }
 }
 module "vpc" {
-
   source  = "so1omon563/vpc/aws"
   version = "2.2.0"
 
@@ -89,13 +102,16 @@ resource "aws_route" "ipv4_default" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
 
 ## Modules
 
@@ -116,7 +132,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | n/a | `string` | `"10.20.32.0/20"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map` | <pre>{<br>  "example": "true"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | <pre>{<br>  "example": "true"<br>}</pre> | no |
 
 ## Outputs
 
@@ -124,5 +140,6 @@ No requirements.
 |------|-------------|
 | <a name="output_custom-network"></a> [custom-network](#output\_custom-network) | n/a |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/custom-named-subnets/example.tf
+++ b/examples/custom-named-subnets/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -8,10 +19,12 @@ provider "aws" {
 }
 
 variable "cidr_block" {
+  type    = string
   default = "10.20.32.0/20"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }

--- a/examples/multiple-subnets/README.md
+++ b/examples/multiple-subnets/README.md
@@ -5,9 +5,21 @@ Example demonstrates some common "slightly more secure" use cases for adding a v
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 locals {
   cidr_block     = "10.20.32.0/20"
   restrict_nacls = true
@@ -49,7 +61,6 @@ output "vpc" {
 
 module "bastion-network" {
   source  = "so1omon563/vpc/aws//modules/subnets"
-
   version = "2.2.0"
 
   vpc_id = module.vpc.vpc_id
@@ -180,13 +191,16 @@ output "endpoints" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
 
 ## Modules
 
@@ -220,5 +234,6 @@ No inputs.
 | <a name="output_bastion-network"></a> [bastion-network](#output\_bastion-network) | n/a |
 | <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-subnets/example.tf
+++ b/examples/multiple-subnets/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 locals {
   cidr_block     = "10.20.32.0/20"
   restrict_nacls = true

--- a/examples/peering-across-region/README.md
+++ b/examples/peering-across-region/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC Peering Connection across regions within the
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   alias  = "requester"
   region = "us-west-1"
@@ -114,14 +126,17 @@ output "peering" { value = module.pcx }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | 5.34.0 |
-| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | 5.34.0 |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 4.0, < 6.0 |
+| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 4.0, < 6.0 |
 
 ## Modules
 
@@ -147,5 +162,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_peering"></a> [peering](#output\_peering) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/peering-across-region/example.tf
+++ b/examples/peering-across-region/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   alias  = "requester"
   region = "us-west-1"

--- a/examples/peering-in-region/README.md
+++ b/examples/peering-in-region/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC Peering Connection in the same region within
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   alias = "requester"
 
@@ -113,14 +125,17 @@ output "peering" { value = module.pcx }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | 5.34.0 |
-| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | 5.34.0 |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 4.0, < 6.0 |
+| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 4.0, < 6.0 |
 
 ## Modules
 
@@ -146,5 +161,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_peering"></a> [peering](#output\_peering) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/peering-in-region/example.tf
+++ b/examples/peering-in-region/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   alias = "requester"
 

--- a/examples/private-only/README.md
+++ b/examples/private-only/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC with ONLY private subnets.
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -36,7 +48,10 @@ output "network" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -61,5 +76,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_network"></a> [network](#output\_network) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/private-only/example.tf
+++ b/examples/private-only/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/public-only/README.md
+++ b/examples/public-only/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC with ONLY public subnets.
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -36,7 +48,10 @@ output "network" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -61,5 +76,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_network"></a> [network](#output\_network) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/public-only/example.tf
+++ b/examples/public-only/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/secondary-cidr/README.md
+++ b/examples/secondary-cidr/README.md
@@ -5,9 +5,21 @@ Example demonstrates adding a secondary CIDR block to a VPC, and then creating s
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -64,7 +76,10 @@ output "lambda_subnets" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -93,5 +108,6 @@ No inputs.
 | <a name="output_lambda_subnets"></a> [lambda\_subnets](#output\_lambda\_subnets) | n/a |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
 | <a name="output_secondary_cidr"></a> [secondary\_cidr](#output\_secondary\_cidr) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/secondary-cidr/example.tf
+++ b/examples/secondary-cidr/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/single-natgw/README.md
+++ b/examples/single-natgw/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC with only 1 NAT Gateway, even though it has 
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -36,7 +48,10 @@ output "network" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -61,5 +76,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_network"></a> [network](#output\_network) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/single-natgw/example.tf
+++ b/examples/single-natgw/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/standard-vpc-ipv6/README.md
+++ b/examples/standard-vpc-ipv6/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC using default values with IPv6 support, and 
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -49,7 +61,10 @@ output "network" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -75,5 +90,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_network"></a> [network](#output\_network) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/standard-vpc-ipv6/example.tf
+++ b/examples/standard-vpc-ipv6/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/standard-vpc/README.md
+++ b/examples/standard-vpc/README.md
@@ -5,9 +5,21 @@ Example demonstrates creating a VPC using only default values, and Gateway Endpo
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -49,7 +61,10 @@ output "endpoints" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -76,5 +91,6 @@ No inputs.
 |------|-------------|
 | <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/standard-vpc/example.tf
+++ b/examples/standard-vpc/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/vpn-gateway/README.md
+++ b/examples/vpn-gateway/README.md
@@ -5,9 +5,21 @@ Example demonstrates a VPN Gateway in a VPC.
 Example shows using Default Tags in the provider as well as passing additional tags into the resource.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -61,7 +73,10 @@ output "vpn" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -88,5 +103,6 @@ No inputs.
 |------|-------------|
 | <a name="output_network"></a> [network](#output\_network) | n/a |
 | <a name="output_vpn"></a> [vpn](#output\_vpn) | n/a |
+
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpn-gateway/example.tf
+++ b/examples/vpn-gateway/example.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/test/basic-usage/main.tf
+++ b/test/basic-usage/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   skip_credentials_validation = true
   skip_requesting_account_id  = true
@@ -11,10 +22,12 @@ provider "aws" {
 }
 
 variable "name" {
+  type    = string
   default = "tf-basic-usage-vpc"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }

--- a/test/custom-named-subnets/main.tf
+++ b/test/custom-named-subnets/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 locals {
   cidr_block     = "10.20.32.0/20"
   restrict_nacls = true
@@ -16,6 +27,7 @@ provider "aws" {
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }

--- a/test/with-ipv6/main.tf
+++ b/test/with-ipv6/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+  }
+}
+
 provider "aws" {
   skip_credentials_validation = true
   skip_requesting_account_id  = true
@@ -11,15 +22,18 @@ provider "aws" {
 }
 
 variable "name" {
+  type    = string
   default = "tf-with-ipv6-vpc"
 }
 
 variable "tags" {
+  type = map(string)
   default = {
     example = "true"
   }
 }
 variable "vpc" {
+  type = map(string)
   default = {
     assign_generated_ipv6_cidr_block = true
   }


### PR DESCRIPTION
## Summary

- declare compatible Terraform and provider requirements in standalone examples and fixtures
- add explicit types to fixture and example variables where needed
- regenerate affected example documentation
- remove only the TFLint exceptions resolved by this change

## Validation

- `terraform fmt -check -recursive`
- `tflint --recursive --config "$(pwd)/.tflint.hcl"`
- `terraform init -backend=false`
- `terraform validate`
- standalone example and fixture `terraform init` / `terraform validate`
- terraform-docs output checks

Tracking: SO1-124