### PR TITLE
fix: type VPC submodule interfaces

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,5 @@
-# Module interface typing is tracked separately from lint tooling.
 rule "terraform_typed_variables" {
-  enabled = false
+  enabled = true
 }
 
 # Retained compatibility declarations are tracked separately from lint tooling.

--- a/modules/dhcp-options/README.md
+++ b/modules/dhcp-options/README.md
@@ -48,7 +48,7 @@ No modules.
 | <a name="input_netbios_name_servers"></a> [netbios\_name\_servers](#input\_netbios\_name\_servers) | List of NETBIOS name servers | `list(string)` | `null` | no |
 | <a name="input_ntp_servers"></a> [ntp\_servers](#input\_ntp\_servers) | List of NTP servers | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the DHCP options | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the DHCP options | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/dhcp-options/vars.tf
+++ b/modules/dhcp-options/vars.tf
@@ -34,5 +34,6 @@ variable "tags" {
 }
 
 variable "vpc_id" {
+  type        = string
   description = "The VPC ID for the DHCP options"
 }

--- a/modules/flow-logs/README.md
+++ b/modules/flow-logs/README.md
@@ -50,7 +50,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_retention_days"></a> [retention\_days](#input\_retention\_days) | The number of days to retain flow log records. | `number` | `365` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the flow logs | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the flow logs | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/flow-logs/vars.tf
+++ b/modules/flow-logs/vars.tf
@@ -28,5 +28,6 @@ variable "tags" {
 }
 
 variable "vpc_id" {
+  type        = string
   description = "The VPC ID for the flow logs"
 }

--- a/modules/gateway-endpoints/by-route-table/README.md
+++ b/modules/gateway-endpoints/by-route-table/README.md
@@ -45,10 +45,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `any` | `null` | no |
+| <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `string` | `null` | no |
 | <a name="input_dynamodb_route_table_ids"></a> [dynamodb\_route\_table\_ids](#input\_dynamodb\_route\_table\_ids) | List of route table IDs to associate with the DynamoDB endpoint | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
-| <a name="input_s3_policy"></a> [s3\_policy](#input\_s3\_policy) | Optional IAM policy to attach to the endpoint that controls access to S3 | `any` | `null` | no |
+| <a name="input_s3_policy"></a> [s3\_policy](#input\_s3\_policy) | Optional IAM policy to attach to the endpoint that controls access to S3 | `string` | `null` | no |
 | <a name="input_s3_route_table_ids"></a> [s3\_route\_table\_ids](#input\_s3\_route\_table\_ids) | List of route table IDs to associate with the S3 endpoint | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
 

--- a/modules/gateway-endpoints/by-route-table/vars.tf
+++ b/modules/gateway-endpoints/by-route-table/vars.tf
@@ -1,4 +1,5 @@
 variable "dynamodb_policy" {
+  type        = string
   description = "Optional IAM policy to attach to the endpoint that controls access to DynamoDB"
   default     = null
 }
@@ -15,6 +16,7 @@ variable "name" {
 }
 
 variable "s3_policy" {
+  type        = string
   description = "Optional IAM policy to attach to the endpoint that controls access to S3"
   default     = null
 }

--- a/modules/gateway-endpoints/by-vpc/README.md
+++ b/modules/gateway-endpoints/by-vpc/README.md
@@ -48,9 +48,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `any` | `null` | no |
+| <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
-| <a name="input_s3_policy"></a> [s3\_policy](#input\_s3\_policy) | Optional IAM policy to attach to the endpoint that controls access to S3 | `any` | `null` | no |
+| <a name="input_s3_policy"></a> [s3\_policy](#input\_s3\_policy) | Optional IAM policy to attach to the endpoint that controls access to S3 | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC the endpoints should be added to. | `string` | n/a | yes |
 

--- a/modules/gateway-endpoints/by-vpc/vars.tf
+++ b/modules/gateway-endpoints/by-vpc/vars.tf
@@ -1,4 +1,5 @@
 variable "dynamodb_policy" {
+  type        = string
   description = "Optional IAM policy to attach to the endpoint that controls access to DynamoDB"
   default     = null
 }
@@ -9,6 +10,7 @@ variable "name" {
 }
 
 variable "s3_policy" {
+  type        = string
   description = "Optional IAM policy to attach to the endpoint that controls access to S3"
   default     = null
 }

--- a/modules/subnet-nacl-rules/generic/README.md
+++ b/modules/subnet-nacl-rules/generic/README.md
@@ -72,7 +72,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | <a name="input_ingress_tcp_ports"></a> [ingress\_tcp\_ports](#input\_ingress\_tcp\_ports) | List of TCP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
 | <a name="input_ingress_udp_ports"></a> [ingress\_udp\_ports](#input\_ingress\_udp\_ports) | List of UDP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
 | <a name="input_ipv6_cidr"></a> [ipv6\_cidr](#input\_ipv6\_cidr) | The IPv6 CIDR block to configure in IPv6-specific NACL rules, typically the VPC IPv6 value, if assigned | `string` | `null` | no |
-| <a name="input_nacl_id"></a> [nacl\_id](#input\_nacl\_id) | The network ACL ID to create rules in | `any` | n/a | yes |
+| <a name="input_nacl_id"></a> [nacl\_id](#input\_nacl\_id) | The network ACL ID to create rules in | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/subnet-nacl-rules/generic/vars.tf
+++ b/modules/subnet-nacl-rules/generic/vars.tf
@@ -1,4 +1,5 @@
 variable "nacl_id" {
+  type        = string
   description = "The network ACL ID to create rules in"
 }
 


### PR DESCRIPTION
## Summary

- declare explicit string types for the remaining VPC, network ACL, and endpoint-policy inputs
- enable the typed-variable lint rule to prevent regressions
- update the affected submodule input tables

## Validation

- `tflint --recursive` with TFLint 0.63.1
- `terraform fmt -check -recursive` with Terraform 1.7.5
- root `terraform validate`
- all three mocked `terraform test` suites
- direct validation of flow logs, DHCP options, route-table endpoints, and generic subnet ACL submodules

The by-VPC endpoint submodule still hits its pre-existing `aws_subnet_ids` incompatibility with the currently selected AWS provider; this patch does not change that resource path.