### PR TITLE
Enable AWS provider 6 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     hooks:
       - id: terraform-fmt
       - id: terraform-validate
+        # These paths require caller-supplied provider aliases and are covered by the provider 6 Terraform test fixture.
+        exclude: ^(modules/peering|test/provider6-compatibility)/
       - id: tflint
         args:
           - "--config=__GIT_ROOT__/.tflint.hcl"

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.34.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_logs"></a> [logs](#module\_logs) | ./modules/flow-logs | n/a |
 | <a name="module_private_subnets"></a> [private\_subnets](#module\_private\_subnets) | ./modules/subnets | n/a |
 | <a name="module_public_subnets"></a> [public\_subnets](#module\_public\_subnets) | ./modules/subnets | n/a |
@@ -49,7 +49,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_default_network_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl) | resource |
 | [aws_default_route_table.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table) | resource |
 | [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
@@ -64,28 +64,26 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.dhcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.dhcp-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_create_flow_logs"></a> [create\_flow\_logs](#input\_create\_flow\_logs) | Whether or not to create flow logs for the VPC. Defaults to `true`, per AWS best practices. | `bool` | `true` | no |
 | <a name="input_flow_logs_kms_key_id"></a> [flow\_logs\_kms\_key\_id](#input\_flow\_logs\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `null` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | The number of days to retain flow log records. | `number` | `365` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_nat_gateway_count"></a> [nat\_gateway\_count](#input\_nat\_gateway\_count) | Total number of NAT gateways to create. If set to `-1`, then a NAT gateway will be created per public subnet. If set to `0`, then no NAT gateways will be created. If set to another number, then that number of NAT gateways will be created, in order from the first available public subnet. | `number` | `-1` | no |
-| <a name="input_private_cidrs"></a> [private\_cidrs](#input\_private\_cidrs) | List of IPv4 CIDR blocks used for private subnets | `list(string)` | <pre>[<br>  "10.255.255.224/28",<br>  "10.255.255.240/28"<br>]</pre> | no |
-| <a name="input_public_cidrs"></a> [public\_cidrs](#input\_public\_cidrs) | List of IPv4 CIDR blocks used for public subnets | `list(string)` | <pre>[<br>  "10.255.255.192/28",<br>  "10.255.255.208/28"<br>]</pre> | no |
+| <a name="input_private_cidrs"></a> [private\_cidrs](#input\_private\_cidrs) | List of IPv4 CIDR blocks used for private subnets | `list(string)` | <pre>[<br/>  "10.255.255.224/28",<br/>  "10.255.255.240/28"<br/>]</pre> | no |
+| <a name="input_public_cidrs"></a> [public\_cidrs](#input\_public\_cidrs) | List of IPv4 CIDR blocks used for public subnets | `list(string)` | <pre>[<br/>  "10.255.255.192/28",<br/>  "10.255.255.208/28"<br/>]</pre> | no |
 | <a name="input_restrict_nacls"></a> [restrict\_nacls](#input\_restrict\_nacls) | If this is set to `true`, network ACL resource created for these subnets will be left empty and deny all ingress and egress traffic. This is useful if you want to manage NACLs outside of this module. If set to `false`, `allow all` ingress and egress NACL rules are created for the subnets | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | A map of VPC properties. Options in `local.vpc_defaults` can be overridden here.<br>  Default values are:<pre>vpc_defaults = {<br>    assign_generated_ipv6_cidr_block = false<br>    cidr_block                       = "10.255.255.192/26"<br>    enable_dns_support               = true<br>    enable_dns_hostnames             = true<br>    instance_tenancy                 = "default"<br>  }</pre>See [aws\_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) for more information on the options | `map(string)` | `{}` | no |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | A map of VPC properties. Options in `local.vpc_defaults` can be overridden here.<br/>  Default values are:<pre>vpc_defaults = {<br/>    assign_generated_ipv6_cidr_block = false<br/>    cidr_block                       = "10.255.255.192/26"<br/>    enable_dns_support               = true<br/>    enable_dns_hostnames             = true<br/>    instance_tenancy                 = "default"<br/>  }</pre>See [aws\_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) for more information on the options | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | The ID of the DHCP options set created by this module. |
 | <a name="output_name_prefix"></a> [name\_prefix](#output\_name\_prefix) | The name prefix of the VPC. Output separately here for convenience. |
 | <a name="output_nat_gateways"></a> [nat\_gateways](#output\_nat\_gateways) | A list of the NAT gateway ids created by this module. |
@@ -98,6 +96,5 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | <a name="output_tags"></a> [tags](#output\_tags) | The tags of the VPC. Output separately here for convenience. |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | A collection of outputs from the created VPC. |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC. Output separately for convenience. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -44,9 +44,9 @@ output "vpc" { value = module.vpc }
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -55,7 +55,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
 ## Resources
@@ -69,8 +69,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/custom-named-subnets/README.md
+++ b/examples/custom-named-subnets/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -103,43 +103,42 @@ resource "aws_route" "ipv4_default" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_custom-network"></a> [custom-network](#module\_custom-network) | so1omon563/vpc/aws//modules/subnets | 2.2.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_internet_gateway.igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_route.ipv4_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | n/a | `string` | `"10.20.32.0/20"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | <pre>{<br>  "example": "true"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | <pre>{<br/>  "example": "true"<br/>}</pre> | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_custom-network"></a> [custom-network](#output\_custom-network) | n/a |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/custom-named-subnets/example.tf
+++ b/examples/custom-named-subnets/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/multiple-subnets/README.md
+++ b/examples/multiple-subnets/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -192,20 +192,20 @@ output "endpoints" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0, < 6.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_bastion-nacl"></a> [bastion-nacl](#module\_bastion-nacl) | so1omon563/vpc/aws//modules/subnet-nacl-rules/generic | 2.2.0 |
 | <a name="module_bastion-network"></a> [bastion-network](#module\_bastion-network) | so1omon563/vpc/aws//modules/subnets | 2.2.0 |
 | <a name="module_cache-network"></a> [cache-network](#module\_cache-network) | so1omon563/vpc/aws//modules/subnets | 2.2.0 |
@@ -220,7 +220,7 @@ output "endpoints" {
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_route.ipv4_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
@@ -230,10 +230,9 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_bastion-network"></a> [bastion-network](#output\_bastion-network) | n/a |
 | <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-subnets/example.tf
+++ b/examples/multiple-subnets/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/peering-across-region/README.md
+++ b/examples/peering-across-region/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -127,21 +127,21 @@ output "peering" { value = module.pcx }
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 4.0, < 6.0 |
-| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 4.0, < 6.0 |
+| ---- | ------- |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 6.0 |
+| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_acp"></a> [acp](#module\_acp) | so1omon563/vpc/aws | 2.2.0 |
 | <a name="module_pcx"></a> [pcx](#module\_pcx) | so1omon563/vpc/aws//modules/peering | 2.2.0 |
 | <a name="module_req"></a> [req](#module\_req) | so1omon563/vpc/aws | 2.2.0 |
@@ -149,7 +149,7 @@ output "peering" { value = module.pcx }
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_route.acp_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.req_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
@@ -160,8 +160,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_peering"></a> [peering](#output\_peering) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/peering-across-region/example.tf
+++ b/examples/peering-across-region/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/peering-in-region/README.md
+++ b/examples/peering-in-region/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -126,21 +126,21 @@ output "peering" { value = module.pcx }
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 4.0, < 6.0 |
-| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 4.0, < 6.0 |
+| ---- | ------- |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 6.0 |
+| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_acp"></a> [acp](#module\_acp) | so1omon563/vpc/aws | 2.2.0 |
 | <a name="module_pcx"></a> [pcx](#module\_pcx) | so1omon563/vpc/aws//modules/peering | 2.2.0 |
 | <a name="module_req"></a> [req](#module\_req) | so1omon563/vpc/aws | 2.2.0 |
@@ -148,7 +148,7 @@ output "peering" { value = module.pcx }
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_route.acp_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.req_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
@@ -159,8 +159,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_peering"></a> [peering](#output\_peering) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/peering-in-region/example.tf
+++ b/examples/peering-in-region/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/private-only/README.md
+++ b/examples/private-only/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -49,9 +49,9 @@ output "network" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -60,7 +60,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
 ## Resources
@@ -74,8 +74,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/private-only/example.tf
+++ b/examples/private-only/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/public-only/README.md
+++ b/examples/public-only/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -49,9 +49,9 @@ output "network" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -60,7 +60,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
 ## Resources
@@ -74,8 +74,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/public-only/example.tf
+++ b/examples/public-only/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/secondary-cidr/README.md
+++ b/examples/secondary-cidr/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -77,9 +77,9 @@ output "lambda_subnets" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -88,7 +88,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_lambda_subnets"></a> [lambda\_subnets](#module\_lambda\_subnets) | so1omon563/vpc/aws//modules/subnets | 2.2.0 |
 | <a name="module_secondary_cidr"></a> [secondary\_cidr](#module\_secondary\_cidr) | so1omon563/vpc/aws//modules/additional-cidr-block-association | 2.2.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
@@ -104,10 +104,9 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_lambda_subnets"></a> [lambda\_subnets](#output\_lambda\_subnets) | n/a |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
 | <a name="output_secondary_cidr"></a> [secondary\_cidr](#output\_secondary\_cidr) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/secondary-cidr/example.tf
+++ b/examples/secondary-cidr/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/single-natgw/README.md
+++ b/examples/single-natgw/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -49,9 +49,9 @@ output "network" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -60,7 +60,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
 ## Resources
@@ -74,8 +74,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/single-natgw/example.tf
+++ b/examples/single-natgw/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/standard-vpc-ipv6/README.md
+++ b/examples/standard-vpc-ipv6/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -62,9 +62,9 @@ output "network" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -73,7 +73,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_endpoints"></a> [endpoints](#module\_endpoints) | so1omon563/vpc/aws//modules/gateway-endpoints/by-route-table | 2.2.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
@@ -88,8 +88,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/standard-vpc-ipv6/example.tf
+++ b/examples/standard-vpc-ipv6/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/standard-vpc/README.md
+++ b/examples/standard-vpc/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -62,9 +62,9 @@ output "endpoints" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -73,7 +73,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_endpoints"></a> [endpoints](#module\_endpoints) | so1omon563/vpc/aws//modules/gateway-endpoints/by-route-table | 2.2.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 
@@ -88,9 +88,8 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/standard-vpc/example.tf
+++ b/examples/standard-vpc/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/vpn-gateway/README.md
+++ b/examples/vpn-gateway/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }
@@ -74,9 +74,9 @@ output "vpn" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
@@ -85,7 +85,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | so1omon563/vpc/aws | 2.2.0 |
 | <a name="module_vpn"></a> [vpn](#module\_vpn) | so1omon563/vpc/aws//modules/vpn-gateway/by-route-table | 2.2.0 |
 
@@ -100,9 +100,8 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_network"></a> [network](#output\_network) | n/a |
 | <a name="output_vpn"></a> [vpn](#output\_vpn) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpn-gateway/example.tf
+++ b/examples/vpn-gateway/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/additional-cidr-block-association/README.md
+++ b/modules/additional-cidr-block-association/README.md
@@ -15,15 +15,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -32,15 +32,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpc_ipv4_cidr_block_association.cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv4_cidr_block_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length`. | `string` | `null` | no |
 | <a name="input_ipv4_ipam_pool_id"></a> [ipv4\_ipam\_pool\_id](#input\_ipv4\_ipam\_pool\_id) | The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. IPAM is a VPC feature that you can use to automate your IP address management workflows including assigning, tracking, troubleshooting, and auditing IP addresses across AWS Regions and accounts. Using IPAM you can monitor IP address usage throughout your AWS Organization. | `string` | `null` | no |
 | <a name="input_ipv4_netmask_length"></a> [ipv4\_netmask\_length](#input\_ipv4\_netmask\_length) | The netmask length of the IPv4 CIDR you want to allocate to this VPC. Requires specifying a `ipv4_ipam_pool_id`. | `number` | `null` | no |
@@ -49,8 +47,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cidr_block_association"></a> [cidr\_block\_association](#output\_cidr\_block\_association) | A collection of outputs from the created CIDR Block Association. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/additional-cidr-block-association/main.tf
+++ b/modules/additional-cidr-block-association/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/dhcp-options/README.md
+++ b/modules/dhcp-options/README.md
@@ -15,15 +15,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -32,18 +32,16 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpc_dhcp_options.dhcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.dhcp-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The suffix domain name to use by default when resolving non Fully Qualified Domain Names | `string` | `null` | no |
-| <a name="input_domain_name_servers"></a> [domain\_name\_servers](#input\_domain\_name\_servers) | List of DNS servers. Default is 'AmazonProvidedDNS' | `list(string)` | <pre>[<br>  "AmazonProvidedDNS"<br>]</pre> | no |
+| <a name="input_domain_name_servers"></a> [domain\_name\_servers](#input\_domain\_name\_servers) | List of DNS servers. Default is 'AmazonProvidedDNS' | `list(string)` | <pre>[<br/>  "AmazonProvidedDNS"<br/>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_netbios_name_servers"></a> [netbios\_name\_servers](#input\_netbios\_name\_servers) | List of NETBIOS name servers | `list(string)` | `null` | no |
 | <a name="input_ntp_servers"></a> [ntp\_servers](#input\_ntp\_servers) | List of NTP servers | `list(string)` | `null` | no |
@@ -53,8 +51,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the created DHCP Options Set. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/dhcp-options/main.tf
+++ b/modules/dhcp-options/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/flow-logs/README.md
+++ b/modules/flow-logs/README.md
@@ -14,15 +14,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -31,20 +31,18 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.flow-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_flow_log.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_iam_role.flow-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.flow-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.ar](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_create_flow_logs"></a> [create\_flow\_logs](#input\_create\_flow\_logs) | Whether or not to create flow logs for the VPC. | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
@@ -55,8 +53,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_log_group"></a> [log\_group](#output\_log\_group) | A collection of outputs from the created Flow Logs Log Group. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/flow-logs/main.tf
+++ b/modules/flow-logs/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/gateway-endpoints/by-route-table/README.md
+++ b/modules/gateway-endpoints/by-route-table/README.md
@@ -15,15 +15,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -32,19 +32,18 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpc_endpoint.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint_route_table_association.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
 | [aws_vpc_endpoint_route_table_association.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `string` | `null` | no |
 | <a name="input_dynamodb_route_table_ids"></a> [dynamodb\_route\_table\_ids](#input\_dynamodb\_route\_table\_ids) | List of route table IDs to associate with the DynamoDB endpoint | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
@@ -55,9 +54,8 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_dynamodb"></a> [dynamodb](#output\_dynamodb) | A collection of outputs from the created DynamoDB Gateway Endpoint. |
 | <a name="output_s3"></a> [s3](#output\_s3) | A collection of outputs from the created S3 Gateway Endpoint. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/gateway-endpoints/by-route-table/dynamodb-gateway.tf
+++ b/modules/gateway-endpoints/by-route-table/dynamodb-gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "dynamodb" {
-  service_name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
   vpc_id       = data.aws_route_table.route_tables.vpc_id
   policy       = var.dynamodb_policy
   tags         = merge(local.tags, { Name = format("%s-dynamodb", var.name) })

--- a/modules/gateway-endpoints/by-route-table/main.tf
+++ b/modules/gateway-endpoints/by-route-table/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/gateway-endpoints/by-route-table/s3-gateway.tf
+++ b/modules/gateway-endpoints/by-route-table/s3-gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "s3" {
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_id       = data.aws_route_table.route_tables.vpc_id
   policy       = var.s3_policy
   tags         = merge(local.tags, { Name = format("%s-s3", var.name) })

--- a/modules/gateway-endpoints/by-vpc/README.md
+++ b/modules/gateway-endpoints/by-vpc/README.md
@@ -17,15 +17,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -34,20 +34,19 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpc_endpoint.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint_route_table_association.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
 | [aws_vpc_endpoint_route_table_association.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
-| [aws_subnet_ids.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dynamodb_policy"></a> [dynamodb\_policy](#input\_dynamodb\_policy) | Optional IAM policy to attach to the endpoint that controls access to DynamoDB | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_s3_policy"></a> [s3\_policy](#input\_s3\_policy) | Optional IAM policy to attach to the endpoint that controls access to S3 | `string` | `null` | no |
@@ -57,9 +56,8 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_dynamodb"></a> [dynamodb](#output\_dynamodb) | A collection of outputs from the created DynamoDB Gateway Endpoint. |
 | <a name="output_s3"></a> [s3](#output\_s3) | A collection of outputs from the created S3 Gateway Endpoint. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/gateway-endpoints/by-vpc/data-sources.tf
+++ b/modules/gateway-endpoints/by-vpc/data-sources.tf
@@ -2,13 +2,16 @@
 
 data "aws_region" "current" {}
 
-# Get  Subnet IDs based on VPC ID
-data "aws_subnet_ids" "subnets" {
-  vpc_id = var.vpc_id
+# Get subnet IDs based on VPC ID
+data "aws_subnets" "subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
 }
 
 # Get route tables
 data "aws_route_table" "route_tables" {
-  for_each  = data.aws_subnet_ids.subnets.ids
+  for_each  = toset(data.aws_subnets.subnets.ids)
   subnet_id = each.value
 }

--- a/modules/gateway-endpoints/by-vpc/dynamodb-gateway.tf
+++ b/modules/gateway-endpoints/by-vpc/dynamodb-gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "dynamodb" {
-  service_name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
   vpc_id       = var.vpc_id
   policy       = var.dynamodb_policy
   tags         = merge(local.tags, { Name = format("%s-dynamodb", var.name) })

--- a/modules/gateway-endpoints/by-vpc/main.tf
+++ b/modules/gateway-endpoints/by-vpc/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/gateway-endpoints/by-vpc/s3-gateway.tf
+++ b/modules/gateway-endpoints/by-vpc/s3-gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "s3" {
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_id       = var.vpc_id
   policy       = var.s3_policy
   tags         = merge(local.tags, { Name : format("%s-s3", var.name) })

--- a/modules/nat-gateway/README.md
+++ b/modules/nat-gateway/README.md
@@ -17,15 +17,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.62.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -34,15 +34,12 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_eip.eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_nat_gateway.natgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_route.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_availability_zones.az](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnets.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_subnets.public_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
@@ -50,7 +47,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_nat_gateway_count"></a> [nat\_gateway\_count](#input\_nat\_gateway\_count) | Total number of NAT gateways to create. If set to `-1`, then a NAT gateway will be created per public subnet. If set to `0`, then no NAT gateways will be created. If set to another number, then that number of NAT gateways will be created, in order from the first available public subnet. | `number` | `-1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
@@ -59,8 +56,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_nat_gateways"></a> [nat\_gateways](#output\_nat\_gateways) | A collection of outputs from the created NAT Gateways. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nat-gateway/main.tf
+++ b/modules/nat-gateway/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/peering/README.md
+++ b/modules/peering/README.md
@@ -21,17 +21,16 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
-| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | 5.39.1 |
-| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 6.0 |
+| <a name="provider_aws.requester"></a> [aws.requester](#provider\_aws.requester) | >= 6.0 |
 
 ## Modules
 
@@ -40,21 +39,19 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpc_peering_connection.pcx](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) | resource |
 | [aws_vpc_peering_connection_accepter.acp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
 | [aws_vpc_peering_connection_options.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) | resource |
 | [aws_vpc_peering_connection_options.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) | resource |
 | [aws_caller_identity.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_region.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_accepter_vpc_id"></a> [accepter\_vpc\_id](#input\_accepter\_vpc\_id) | The ID of the accepter VPC | `string` | n/a | yes |
 | <a name="input_allow_remote_dns"></a> [allow\_remote\_dns](#input\_allow\_remote\_dns) | Allow resolution of public DNS hostnames to private IP addresses across the peering connection | `bool` | `false` | no |
 | <a name="input_auto_accept"></a> [auto\_accept](#input\_auto\_accept) | Automatically accept the VPC peering connection request | `bool` | `false` | no |
@@ -65,8 +62,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_peering_connection"></a> [peering\_connection](#output\_peering\_connection) | A collection of outputs from the created VPC Peering Connection. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/peering/main.tf
+++ b/modules/peering/main.tf
@@ -5,8 +5,9 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      source                = "hashicorp/aws"
+      version               = ">= 6.0"
+      configuration_aliases = [aws.requester, aws.accepter]
     }
   }
 }

--- a/modules/peering/vpc-peer.tf
+++ b/modules/peering/vpc-peer.tf
@@ -2,7 +2,7 @@ resource "aws_vpc_peering_connection" "pcx" {
   provider      = aws.requester
   auto_accept   = false
   peer_owner_id = data.aws_caller_identity.accepter.account_id
-  peer_region   = data.aws_region.accepter.name
+  peer_region   = data.aws_region.accepter.region
   peer_vpc_id   = var.accepter_vpc_id
   vpc_id        = var.requester_vpc_id
   tags          = merge(local.tags, { Name = format("%s", var.name) })
@@ -17,7 +17,7 @@ resource "aws_vpc_peering_connection_accepter" "acp" {
 }
 
 resource "aws_vpc_peering_connection_options" "requester" {
-  count    = data.aws_region.requester.name == data.aws_region.accepter.name && var.auto_accept ? 1 : 0
+  count    = data.aws_region.requester.region == data.aws_region.accepter.region && var.auto_accept ? 1 : 0
   provider = aws.requester
 
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.acp.vpc_peering_connection_id
@@ -28,7 +28,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
-  count    = data.aws_region.requester.name == data.aws_region.accepter.name && var.auto_accept ? 1 : 0
+  count    = data.aws_region.requester.region == data.aws_region.accepter.region && var.auto_accept ? 1 : 0
   provider = aws.accepter
 
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.acp.vpc_peering_connection_id

--- a/modules/subnet-nacl-rules/generic/README.md
+++ b/modules/subnet-nacl-rules/generic/README.md
@@ -26,26 +26,26 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_base"></a> [base](#module\_base) | ../service | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_network_acl_rule.ipv4-tcp-egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ipv4-tcp-ingress-ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ipv4-udp-egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -58,17 +58,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | [aws_network_acl_rule.vpc-ipv4-ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.vpc-ipv6-egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.vpc-ipv6-ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_egress_tcp_ports"></a> [egress\_tcp\_ports](#input\_egress\_tcp\_ports) | List of additional TCP port numbers for creating egress NACL rules, combined with values in `local.egress_udp_ports_defaults` - `[80, 443]` | `list(number)` | `[]` | no |
 | <a name="input_egress_udp_ports"></a> [egress\_udp\_ports](#input\_egress\_udp\_ports) | List of additional UDP port numbers for creating egress NACL rules, combined with values in `local.egress_udp_ports_defaults` - `[123]` | `list(number)` | `[]` | no |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Toggle to create NACL rules for the value specified in ipv6\_cidr\_block | `bool` | `false` | no |
-| <a name="input_extra_ipv4_cidr"></a> [extra\_ipv4\_cidr](#input\_extra\_ipv4\_cidr) | List of additional CIDR blocks to grant full access NACL rules.<br>  Combined with values in `local.extra_ipv4_cidr_defaults` - `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]` | `list(string)` | `[]` | no |
+| <a name="input_extra_ipv4_cidr"></a> [extra\_ipv4\_cidr](#input\_extra\_ipv4\_cidr) | List of additional CIDR blocks to grant full access NACL rules.<br/>  Combined with values in `local.extra_ipv4_cidr_defaults` - `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]` | `list(string)` | `[]` | no |
 | <a name="input_ingress_tcp_ports"></a> [ingress\_tcp\_ports](#input\_ingress\_tcp\_ports) | List of TCP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
 | <a name="input_ingress_udp_ports"></a> [ingress\_udp\_ports](#input\_ingress\_udp\_ports) | List of UDP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
 | <a name="input_ipv6_cidr"></a> [ipv6\_cidr](#input\_ipv6\_cidr) | The IPv6 CIDR block to configure in IPv6-specific NACL rules, typically the VPC IPv6 value, if assigned | `string` | `null` | no |
@@ -77,6 +75,5 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Outputs
 
 No outputs.
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/subnet-nacl-rules/generic/main.tf
+++ b/modules/subnet-nacl-rules/generic/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/subnet-nacl-rules/service/README.md
+++ b/modules/subnet-nacl-rules/service/README.md
@@ -19,15 +19,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -36,7 +36,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_network_acl_rule.egress-ipv4-tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.egress-ipv4-udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.egress-ipv6-tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -45,13 +45,11 @@ No modules.
 | [aws_network_acl_rule.ingress-ipv4-udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ingress-ipv6-tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ingress-ipv6-udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Toggle to create NACL rules for the value specified in ipv6\_cidr\_block | `bool` | `false` | no |
 | <a name="input_ingress_tcp_ports"></a> [ingress\_tcp\_ports](#input\_ingress\_tcp\_ports) | List of TCP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
 | <a name="input_ingress_udp_ports"></a> [ingress\_udp\_ports](#input\_ingress\_udp\_ports) | List of UDP port numbers for creating ingress NACL rules | `list(number)` | `[]` | no |
@@ -62,6 +60,5 @@ No modules.
 ## Outputs
 
 No outputs.
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/subnet-nacl-rules/service/main.tf
+++ b/modules/subnet-nacl-rules/service/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -15,15 +15,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -32,7 +32,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_network_acl.nacl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl_rule.ipv4_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.ipv4_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -42,13 +42,11 @@ No modules.
 | [aws_route_table_association.route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_subnet.subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_availability_zones.az](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ipv4_cidr_blocks"></a> [ipv4\_cidr\_blocks](#input\_ipv4\_cidr\_blocks) | List of IPv4 cidr blocks to configure subnets | `list(string)` | n/a | yes |
 | <a name="input_ipv6_cidr_blocks"></a> [ipv6\_cidr\_blocks](#input\_ipv6\_cidr\_blocks) | List of IPv6 cidr blocks to configure subnets. If specified, length must match ipv4\_cidr\_blocks | `list(string)` | `[]` | no |
 | <a name="input_isolate_route_tables"></a> [isolate\_route\_tables](#input\_isolate\_route\_tables) | If `true`, a route table will be created for each subnet, otherwise a single route table will be created for all subnets managed by this module | `bool` | `false` | no |
@@ -65,11 +63,10 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_nacl"></a> [nacl](#output\_nacl) | A collection of outputs from the NACL created by this module. |
 | <a name="output_route_table_ids"></a> [route\_table\_ids](#output\_route\_table\_ids) | A list of the route table ids created by this module. |
 | <a name="output_route_table_names"></a> [route\_table\_names](#output\_route\_table\_names) | A list of the route table names created by this module. |
 | <a name="output_subnets"></a> [subnets](#output\_subnets) | A collection of outputs from the created Subnets. |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/vpn-gateway/by-route-table/README.md
+++ b/modules/vpn-gateway/by-route-table/README.md
@@ -15,15 +15,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -32,18 +32,16 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpn_gateway.vgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway) | resource |
 | [aws_vpn_gateway_attachment.attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_attachment) | resource |
 | [aws_vpn_gateway_route_propagation.routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number for the AWS side of the gateway. | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_route_table_ids"></a> [route\_table\_ids](#input\_route\_table\_ids) | List of route table IDs to propagate VPN routes into. | `list(string)` | n/a | yes |
@@ -52,8 +50,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpn_gateway_id"></a> [vpn\_gateway\_id](#output\_vpn\_gateway\_id) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpn-gateway/by-route-table/main.tf
+++ b/modules/vpn-gateway/by-route-table/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/vpn-gateway/by-vpc/README.md
+++ b/modules/vpn-gateway/by-vpc/README.md
@@ -17,15 +17,15 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.1 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -34,19 +34,17 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_vpn_gateway.vgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway) | resource |
 | [aws_vpn_gateway_attachment.attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_attachment) | resource |
 | [aws_vpn_gateway_route_propagation.routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route_table.route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
-| [aws_subnet_ids.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number for the AWS side of the gateway. | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Short, descriptive name of the environment. All resources will be named using this value as a prefix. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tag names and values for tags to apply to all taggable resources created by the module. Default value is a blank map to allow for using Default Tags in the provider. | `map(string)` | `{}` | no |
@@ -55,8 +53,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpn_gateway_id"></a> [vpn\_gateway\_id](#output\_vpn\_gateway\_id) | n/a |
-
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpn-gateway/by-vpc/data-sources.tf
+++ b/modules/vpn-gateway/by-vpc/data-sources.tf
@@ -1,11 +1,15 @@
 # This file is for data sources that may be required for the module to run.
 
-# Get  Subnet IDs based on VPC ID
-data "aws_subnet_ids" "subnets" {
-  vpc_id = var.vpc_id
+# Get subnet IDs based on VPC ID
+data "aws_subnets" "subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
 }
+
 # Get route tables
 data "aws_route_table" "route_tables" {
-  for_each  = data.aws_subnet_ids.subnets.ids
+  for_each  = toset(data.aws_subnets.subnets.ids)
   subnet_id = each.value
 }

--- a/modules/vpn-gateway/by-vpc/main.tf
+++ b/modules/vpn-gateway/by-vpc/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/test/basic-usage/main.tf
+++ b/test/basic-usage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/test/custom-named-subnets/main.tf
+++ b/test/custom-named-subnets/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/test/provider6-compatibility/main.tf
+++ b/test/provider6-compatibility/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/test/provider6-compatibility/main.tftest.hcl
+++ b/test/provider6-compatibility/main.tftest.hcl
@@ -1,0 +1,121 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-east-1"
+    }
+  }
+
+  mock_data "aws_subnets" {
+    defaults = {
+      ids = ["subnet-1", "subnet-2"]
+    }
+  }
+
+  mock_data "aws_route_table" {
+    defaults = {
+      id = "rtb-test"
+    }
+  }
+}
+
+mock_provider "aws" {
+  alias = "requester"
+
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-west-1"
+    }
+  }
+}
+
+mock_provider "aws" {
+  alias = "accepter"
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-west-2"
+    }
+  }
+}
+
+run "gateway_endpoints_discover_route_tables_by_vpc" {
+  command = plan
+
+  module {
+    source = "../../modules/gateway-endpoints/by-vpc"
+  }
+
+  variables {
+    name   = "provider6-test"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.s3.service_name == "com.amazonaws.us-east-1.s3"
+    error_message = "S3 gateway endpoint did not use the provider region."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint_route_table_association.s3) == 2
+    error_message = "S3 gateway endpoint did not discover both subnet route tables."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint_route_table_association.dynamodb) == 2
+    error_message = "DynamoDB gateway endpoint did not discover both subnet route tables."
+  }
+}
+
+run "vpn_gateway_discovers_route_tables_by_vpc" {
+  command = plan
+
+  module {
+    source = "../../modules/vpn-gateway/by-vpc"
+  }
+
+  variables {
+    name   = "provider6-test"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = length(aws_vpn_gateway_route_propagation.routes) == 2
+    error_message = "VPN gateway did not discover both subnet route tables."
+  }
+}
+
+run "peering_uses_declared_provider_aliases" {
+  command = plan
+
+  module {
+    source = "../../modules/peering"
+  }
+
+  providers = {
+    aws.requester = aws.requester
+    aws.accepter  = aws.accepter
+  }
+
+  variables {
+    accepter_vpc_id  = "vpc-accepter"
+    auto_accept      = true
+    name             = "provider6-test"
+    requester_vpc_id = "vpc-requester"
+  }
+
+  assert {
+    condition     = aws_vpc_peering_connection.pcx.peer_region == "us-west-2"
+    error_message = "Peering connection did not use the accepter provider region."
+  }
+
+  assert {
+    condition     = length(aws_vpc_peering_connection_options.requester) == 0
+    error_message = "Cross-region peering unexpectedly created requester DNS options."
+  }
+}

--- a/test/with-ipv6/main.tf
+++ b/test/with-ipv6/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- require AWS provider 6 across the root module, reusable submodules, examples, and native tests
- replace removed subnet discovery and deprecated region attributes, and declare the peering provider aliases
- add focused mocked plans for by-VPC gateway endpoints, by-VPC VPN propagation, and cross-region peering
- refresh generated provider requirements documentation

## Validation

- Terraform 1.7.5 with AWS provider 6.55.0: root init and validate
- all 12 examples: init and validate
- 11 standalone reusable submodules: init and validate
- peering alias contract: covered by the provider-6 compatibility fixture
- native Terraform tests: 6/6 runs passed
- Terraform formatting, TFLint, terraform-docs, and repository hygiene hooks passed

The repository-wide Checkov hook still reports 41 pre-existing findings: 31 registry module-source pinning findings that conflict with this portfolio's immutable-version convention, one existing flow-log IAM finding, and nine existing NACL findings. This change does not introduce or alter those resources.

## State and release

- no managed-resource addresses or state migrations
- default patch bump on merge
- no `#release` marker; this does not require GitHub Release publication

Linear: SO1-192
